### PR TITLE
Added option to combine stopping conditions

### DIFF
--- a/PyCROSL/CRO_SL.py
+++ b/PyCROSL/CRO_SL.py
@@ -5,6 +5,7 @@ import warnings
 import numpy as np
 from PyCROSL.CoralPopulation import CoralPopulation
 from matplotlib import pyplot as plt
+import pyparsing as pp
 # import json
 
 
@@ -47,6 +48,8 @@ class CRO_SL:
 
         # Stopping conditions
         self.stop_cond = params["stop_cond"]
+        self.stop_cond_parsed = parse_stopping_cond(self.stop_cond)
+
         self.Ngen = params["Ngen"]
         self.Neval = params["Neval"]
         self.time_limit = params["time_limit"]
@@ -119,42 +122,41 @@ class CRO_SL:
         """
         Stopping conditions given by a parameter
         """
-        
-        stop = True
-        if self.stop_cond == "Neval":
-            stop = self.objfunc.counter >= self.Neval
-        elif self.stop_cond == "Ngen":
-            stop = gen >= self.Ngen
-        elif self.stop_cond == "time":
-            stop = time.time()-time_start >= self.time_limit
-        elif self.stop_cond == "fit_target":
-            if self.objfunc.opt == "max":
-                stop = self.population.best_solution()[1] >= self.fit_target
-            else:
-                stop = self.population.best_solution()[1] <= self.fit_target
 
-        return stop
+        neval_reached = self.objfunc.counter >= self.Neval
+
+        ngen_reached = gen >= self.Ngen
+
+        real_time_reached = time.time() - time_start >= self.time_limit
+
+        if self.objfunc.opt == "max":
+            target_reached = self.best_solution()[1] >= self.fit_target
+        else:
+            target_reached = self.best_solution()[1] <= self.fit_target
+
+        return process_condition(self.stop_cond_parsed, neval_reached, ngen_reached, real_time_reached, target_reached)
 
     
     def progress(self, gen, time_start):
         """
         Progress of the algorithm as a number between 0 and 1, 0 at the begining, 1 at the end
         """
-        
-        prog = 0
-        if self.stop_cond == "Neval":
-            prog = self.objfunc.counter/self.Neval
-        elif self.stop_cond == "Ngen":
-            prog = gen/self.Ngen 
-        elif self.stop_cond == "time":
-            prog = (time.time()-time_start)/self.time_limit
-        elif self.stop_cond == "fit_target":
-            if self.objfunc.opt == "max":
-                prog = self.population.best_solution()[1]/self.fit_target
-            else:
-                prog = self.fit_target/self.population.best_solution()[1]
 
-        return prog
+        neval_reached = self.objfunc.counter/self.Neval
+        
+        ngen_reached = gen/self.Ngen
+
+        real_time_reached = (time.time() - time_start)/self.time_limit
+
+        best_fitness = self.best_solution()[1]
+        if self.objfunc.opt == "max":
+            target_reached = best_fitness/self.fit_target
+        else:
+            if best_fitness == 0:
+                best_fitness = 1e-15
+            target_reached = self.fit_target/best_fitness
+
+        return process_progress(self.stop_cond_parsed, neval_reached, ngen_reached, real_time_reached, target_reached)
     
     
     def save_data(self, solution_file="best_solution.csv", population_file="last_population.csv", history_file="fit_history.csv", prob_file="prob_history.csv", indiv_history="indiv_history.csv"):
@@ -488,3 +490,91 @@ class CRO_SL:
                 plt.savefig(f"figures/{figure_name}")
 
             plt.show()
+
+
+def parse_stopping_cond(condition_str):
+    """
+    This function parses an expression of the form "neval or cpu_time" into
+    a tree structure so that it can be futher processed.
+    """
+
+    orop = pp.Literal("and")
+    andop = pp.Literal("or")
+    condition = pp.oneOf(["Neval", "Ngen", "time_limit", "fit_target"])
+
+    expr = pp.infixNotation(
+        condition,
+        [
+            (orop, 2, pp.opAssoc.RIGHT),
+            (andop, 2, pp.opAssoc.RIGHT)
+        ]
+    )
+
+    return expr.parse_string(condition_str).as_list()
+
+
+def process_condition(cond_parsed, neval, ngen, real_time, target):
+    """
+    This function recieves as an input an expression for the stopping condition
+    and the truth variable of the possible stopping conditions and returns wether to stop or not.
+    """
+
+    result = None
+
+    if isinstance(cond_parsed, list):
+        if len(cond_parsed) == 3:
+            cond1 = process_condition(cond_parsed[0], neval, ngen, real_time, target)
+            cond2 = process_condition(cond_parsed[2], neval, ngen, real_time, target)
+
+            if cond_parsed[1] == "or":
+                result = cond1 or cond2
+            elif cond_parsed[1] == "and":
+                result = cond1 and cond2
+
+        elif len(cond_parsed) == 1:
+            result = process_condition(cond_parsed[0], neval, ngen, real_time, target)
+
+    else:
+        if cond_parsed == "Neval":
+            result = neval
+        elif cond_parsed == "Ngen":
+            result = ngen
+        elif cond_parsed == "time_limit":
+            result = real_time
+        elif cond_parsed == "fit_target":
+            result = target
+    
+    return result
+
+
+def process_progress(cond_parsed, neval, ngen, real_time, target):
+    """
+    This function recieves as an input an expression for the stopping condition 
+    and the truth variable of the possible stopping conditions and returns wether to stop or not. 
+    """
+    result = None
+    
+    if isinstance(cond_parsed, list):
+        if len(cond_parsed) == 3:
+            
+            progress1 = process_progress(cond_parsed[0], neval, ngen, real_time, target)
+            progress2 = process_progress(cond_parsed[2], neval, ngen, real_time, target)
+
+            if cond_parsed[1] == "or":
+                result = max(progress1, progress2)
+            elif cond_parsed[1] == "and":
+                result = min(progress1, progress2)
+            
+        elif len(cond_parsed) == 1:
+            result = process_progress(cond_parsed[0], neval, ngen, real_time, target)
+    else:
+        if cond_parsed == "Neval":
+            result = neval
+        elif cond_parsed == "Ngen":
+            result = ngen
+        elif cond_parsed == "time_limit":
+            result = real_time
+        elif cond_parsed == "fit_target":
+            result = target
+
+    return result

--- a/PyCROSL/CRO_SL.py
+++ b/PyCROSL/CRO_SL.py
@@ -515,7 +515,7 @@ def parse_stopping_cond(condition_str):
 
 def process_condition(cond_parsed, neval, ngen, real_time, target):
     """
-    This function recieves as an input an expression for the stopping condition
+    This function receives as an input an expression for the stopping condition
     and the truth variable of the possible stopping conditions and returns wether to stop or not.
     """
 
@@ -549,7 +549,7 @@ def process_condition(cond_parsed, neval, ngen, real_time, target):
 
 def process_progress(cond_parsed, neval, ngen, real_time, target):
     """
-    This function recieves as an input an expression for the stopping condition 
+    This function receives as an input an expression for the stopping condition 
     and the truth variable of the possible stopping conditions and returns wether to stop or not. 
     """
     result = None

--- a/PyCROSL/CoralPopulation.py
+++ b/PyCROSL/CoralPopulation.py
@@ -1,7 +1,7 @@
 import random
 
 import numpy as np
-from numba import jit
+# from numba import jit
 from PyCROSL.operators import *
 from joblib import Parallel, delayed 
 

--- a/PyCROSL/main.py
+++ b/PyCROSL/main.py
@@ -117,6 +117,61 @@ def test_cro():
     print(ind)
     c.display_report()
 
+def test_multi_cond():
+    substrates_real = [
+        SubstrateReal("1point"),
+        SubstrateReal("Gauss", {"F":0.001}),
+    ]
+
+    params = {
+        "popSize": 500,
+        "rho": 0.6,
+        "Fb": 0.98,
+        "Fd": 0.2,
+        "Pd": 0.8,
+        "k": 3,
+        "K": 20,
+        "group_subs": True,
+
+        "stop_cond": "time_limit or Ngen or Neval or fit_target",
+        "time_limit": 9999,
+        "Ngen": 9999,
+        "Neval": 9999999,
+        "fit_target": 0,
+
+        "verbose": False,
+        "v_timer": 1,
+        "Njobs": 1,
+
+        "dynamic": True,
+        "dyn_method": "success",
+        "dyn_metric": "avg",
+        "dyn_steps": 10,
+        "prob_amp": 0.01
+    }
+
+    # Testing three conditions: Ngen or fit_target or time_limit
+    objfunc = Rastrigin(2)
+
+    stopping_values = {"time_limit": 3, "Ngen": 200, "Neval": 1000, "fit_target": 0.1}
+    for criterion_name, criterion_val in stopping_values.items():
+        params_ = params.copy()
+        params_[criterion_name] = criterion_val
+
+        print('-'*50)
+        print(f"Should stop with '{criterion_name}' reaching {criterion_val}")
+        print('-'*50)
+
+        c = CRO_SL(objfunc, substrates_real, params_)
+        c.restart()
+        _, fit = c.optimize()
+
+        print(f"Generations: {len(c.history)}")
+        print(f"Time spent: {round(c.real_time_spent, 3)}s")
+        print(f"Best fitness: {fit}")
+        print(f"Fitness evaluations: {c.objfunc.counter}")
+
+
 def test_files():
     params = {
         "popSize": 100,
@@ -270,9 +325,10 @@ def test_parallelism():
 
 def main():
     #thirty_runs()
-    test_cro()
+    #test_cro()
+    test_multi_cond()
     #test_files()
-    # test_parallelism()
+    #test_parallelism()
 
 if __name__ == "__main__":
     main()

--- a/PyCROSL/main.py
+++ b/PyCROSL/main.py
@@ -81,7 +81,7 @@ def test_cro():
         "K": 20,
         "group_subs": True,
 
-        "stop_cond": "ngen",
+        "stop_cond": "Ngen or Neval",
         "time_limit": 4000.0,
         "Ngen": 200,
         "Neval": 10e5,
@@ -112,6 +112,7 @@ def test_cro():
     c.display_report()
 
     c = CRO_SL(objfunc, substrates_int, params)
+    c.restart() # reset the objective function counter
     ind, fit = c.optimize()
     print(ind)
     c.display_report()
@@ -127,7 +128,7 @@ def test_files():
         "K": 20,
         "group_subs": False,
 
-        "stop_cond": "neval",
+        "stop_cond": "Neval",
         "time_limit": 4000.0,
         "Ngen": 3500,
         "Neval": 1e5,
@@ -240,7 +241,7 @@ def test_parallelism():
             "K": 20,
             "group_subs": True,
 
-            "stop_cond": "ngen",
+            "stop_cond": "Ngen",
             "time_limit": 4000.0,
             "Ngen": 20,
             "Neval": 10e5,

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ numpy==1.22.0
 pandas==1.5.0
 scipy==1.10.1
 joblib==1.2.0
+pyparsing==3.1.0


### PR DESCRIPTION
Stopping conditions can now be specified as a combination of other stopping conditions, this is compatible with old code.

There are 4 base stopping conditions:
- Ngen: stop after a number of generations
- Neval: stop after a number of fitness function evaluations
- time_limit: stop after a specified amount of time has passed
- fit_target: stop when a fitness target is reached

There are 2 ways of combining them, with "and" and "or", parenthesis also work.
For example:
- Ngen or time_limit: stop when either a number of generations has been reached or an amount time has passed
- time_limit and fit_target: stop when both an amount time has passed and a fitness target has been reached. 
- fit_target and (Ngen or Neval): stop when a fitness target has been reached and a number of generations or evaluations has been reached.

