### PR TITLE
fixing parallel CRO not incrementing number of fitness evaluations

### DIFF
--- a/PyCROSL/CoralPopulation.py
+++ b/PyCROSL/CoralPopulation.py
@@ -332,7 +332,9 @@ class CoralPopulation:
         else:
             # Separate corals into "N_jobs" partitions of equal size
             partitions = np.array_split(corals, n_jobs)
+            n_corals_to_evaluate = len([c for c in corals if not c.fitness_calculated])
             results = Parallel(n_jobs=n_jobs)(delayed(self.evaluate_fitnesses)(part, 1) for part in partitions)
+            self.objfunc.counter += n_corals_to_evaluate
             return [c for p in results for c in p]
 
     """


### PR DESCRIPTION
There was a bug in the parallel CRO implementation where the objective function's counter was not being incremented when the fitness() function was called. This happened because this counter is incremented inside the fitness() function, however since this function is called by joblib, the class parameter `counter` is not updated.

This commit fixes this by manually incrementing the counter when `evaluate_fitnesses` is called with Njobs > 1.